### PR TITLE
`vectorizer.get_feature_names` method update due to `scikit-learn>=1.2`

### DIFF
--- a/malaya/topic_model/decomposition.py
+++ b/malaya/topic_model/decomposition.py
@@ -178,7 +178,7 @@ def fit(
             corpus[i] = cleaning(corpus[i])
 
     tf = vectorizer.fit_transform(corpus)
-    tf_features = vectorizer.get_feature_names()
+    tf_features = vectorizer.get_feature_names_out()
     compose = model(n_topics).fit(tf)
     return Topic(
         tf_features, compose, corpus, compose.transform(tf), vectorizer, tf


### PR DESCRIPTION
Hi Husein, minor code change for this issue: #211 

Tested on Python 3.10.12.

Dependencies:
```
git+https://github.com/wanadzhar913/malaya
dateparser==1.2.0
scikit-learn==1.2.2
requests==2.31.0
unidecode==1.3.8
numpy==1.25.2
scipy==1.11.4
ftfy==6.2.0
networkx==3.3
sentencepiece==0.1.99
tqdm==4.66.4
malaya-boilerplate==0.0.25
regex==2024.5.15
transformers==4.42.4
```